### PR TITLE
feature : A trivy server URL in plugin settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.aquasecurity.plugins'
-version '1.4.1'
+version '1.5.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/aquasecurity/plugins/trivy/actions/TrivyBackgroundRunTask.java
+++ b/src/main/java/com/aquasecurity/plugins/trivy/actions/TrivyBackgroundRunTask.java
@@ -58,6 +58,9 @@ class TrivyBackgroundRunTask extends Task.Backgroundable implements Runnable {
         if (TrivySettingState.getInstance().IgnoreUnfixed) {
             commandParts.add("--ignore-unfixed");
         }
+        if (TrivySettingState.getInstance().ServerEnabled && !TrivySettingState.getInstance().RemoteServerURL.isEmpty()) {
+            commandParts.add(String.format("--server=%s", TrivySettingState.getInstance().RemoteServerURL));
+        }
 
         commandParts.add("--format=json");
         commandParts.add(String.format("--output=%s", resultFile.getAbsolutePath()));

--- a/src/main/java/com/aquasecurity/plugins/trivy/settings/TrivySettingState.java
+++ b/src/main/java/com/aquasecurity/plugins/trivy/settings/TrivySettingState.java
@@ -25,6 +25,8 @@ public class TrivySettingState implements PersistentStateComponent<TrivySettingS
     public boolean OfflineScan = false;
     public boolean IgnoreUnfixed = false;
     public boolean SecretScanning = false;
+    public boolean ServerEnabled = false;
+    public String RemoteServerURL ="";
 
     public static TrivySettingState getInstance() {
         return ApplicationManager.getApplication().getService(TrivySettingState.class);

--- a/src/main/java/com/aquasecurity/plugins/trivy/settings/TrivySettingsComponent.java
+++ b/src/main/java/com/aquasecurity/plugins/trivy/settings/TrivySettingsComponent.java
@@ -3,19 +3,15 @@ package com.aquasecurity.plugins.trivy.settings;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
-import com.intellij.ui.HintHint;
 import com.intellij.ui.JBSplitter;
 import com.intellij.ui.TitledSeparator;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
-import com.intellij.ui.components.JBPanel;
+import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import javax.swing.border.Border;
-import javax.swing.border.TitledBorder;
-import java.awt.*;
 
 /**
  * Supports creating and managing a {@link JPanel} for the Settings Dialog.
@@ -32,6 +28,8 @@ public class TrivySettingsComponent {
     private final JBCheckBox OfflineScan = new JBCheckBox("Offline scan");
     private final JBCheckBox SecretScanning = new JBCheckBox("Enable secret scanning");
     private final JBCheckBox IgnoreUnfixed = new JBCheckBox("Only show issues with fixes");
+    private final JBCheckBox ServerEnabled = new JBCheckBox("Server Enabled");
+    private final JBTextField RemoteServerURL = new JBTextField("");
 
 
     public TrivySettingsComponent() {
@@ -49,6 +47,9 @@ public class TrivySettingsComponent {
                 .addLabeledComponent(new JBLabel(), MediumSeverity, 1, false)
                 .addLabeledComponent(new JBLabel(), LowSeverity, 1, false)
                 .addLabeledComponent(new JBLabel(), UnknownSeverity, 1, false)
+                .addComponent(new TitledSeparator("The Remote Trivy url to connect to "))
+                .addLabeledComponent(new JBLabel(), ServerEnabled, 1, false)
+                .addLabeledComponent(new JBLabel(), RemoteServerURL, 1, false)
                 .addComponent(new TitledSeparator("Other Settings"))
                 .addLabeledComponent(new JBLabel(), OfflineScan, 1, false)
                 .addLabeledComponent(new JBLabel(), IgnoreUnfixed, 1, false)
@@ -110,6 +111,9 @@ public class TrivySettingsComponent {
     public boolean getSecretScanning() {
         return SecretScanning.isSelected();
     }
+    @NotNull
+    public boolean getServerEnabled() { return ServerEnabled.isSelected(); }
+    public String getRemoteServerURL() { return RemoteServerURL.getText(); }
 
 
     public void setTrivyPath(@NotNull String newText) {
@@ -131,5 +135,7 @@ public class TrivySettingsComponent {
     public void setIgnoreUnfixed(@NotNull boolean required) { IgnoreUnfixed.setSelected(required);    }
 
     public void setSecretScanning(@NotNull boolean required) {SecretScanning.setSelected(required);}
+    public void setServerEnabled(@NotNull boolean required) {ServerEnabled.setSelected(required);}
+    public void setRemoteServerURL(@NotNull String newText) {RemoteServerURL.setText(newText);}
 
 }

--- a/src/main/java/com/aquasecurity/plugins/trivy/settings/TrivySettingsConfigurable.java
+++ b/src/main/java/com/aquasecurity/plugins/trivy/settings/TrivySettingsConfigurable.java
@@ -46,7 +46,9 @@ public class TrivySettingsConfigurable implements Configurable {
                 !TrivySettingsComponent.getUnknownSeverityRequired() == settings.UnknownSeverity ||
                 !TrivySettingsComponent.getOfflineScanRequired() == settings.OfflineScan ||
                 !TrivySettingsComponent.getShowOnlyFixed() == settings.IgnoreUnfixed ||
-                !TrivySettingsComponent.getSecretScanning() == settings.SecretScanning
+                !TrivySettingsComponent.getSecretScanning() == settings.SecretScanning||
+                !TrivySettingsComponent.getServerEnabled() == settings.ServerEnabled||
+                !TrivySettingsComponent.getRemoteServerURL().equals(settings.RemoteServerURL)
                 ;
         return modified;
     }
@@ -62,7 +64,9 @@ public class TrivySettingsConfigurable implements Configurable {
         settings.UnknownSeverity = TrivySettingsComponent.getUnknownSeverityRequired();
         settings.OfflineScan = TrivySettingsComponent.getOfflineScanRequired();
         settings.IgnoreUnfixed = TrivySettingsComponent.getShowOnlyFixed();
-settings.SecretScanning = TrivySettingsComponent.getSecretScanning();
+        settings.SecretScanning = TrivySettingsComponent.getSecretScanning();
+        settings.ServerEnabled = TrivySettingsComponent.getServerEnabled();
+        settings.RemoteServerURL = TrivySettingsComponent.getRemoteServerURL();
     }
 
     @Override
@@ -77,6 +81,8 @@ settings.SecretScanning = TrivySettingsComponent.getSecretScanning();
         TrivySettingsComponent.setOfflineScan(settings.OfflineScan);
         TrivySettingsComponent.setIgnoreUnfixed(settings.IgnoreUnfixed);
         TrivySettingsComponent.setSecretScanning(settings.SecretScanning);
+        TrivySettingsComponent.setServerEnabled(settings.ServerEnabled);
+        TrivySettingsComponent.setRemoteServerURL(settings.RemoteServerURL);
 
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,8 @@
 Scan your project for package vulnerabilities and infrastructure as code misconfigurations using Trivy.<br />
 Navigate your Trivy results in the Findings Explorer with additional information in the Help Pane about how to resolve.
     ]]></description>
-    <change-notes><![CDATA[v1.4.1 - Gracefully handle virtual errors, files in tarballs<br /<>
+    <change-notes><![CDATA[v1.5.0 - Add support for remote server url to connect <br />
+v1.4.1 - Gracefully handle virtual errors, files in tarballs<br />
 v1.4.0 - Add support for secrets, fix links<br />
 v1.3.1 - Fix issue where results with no line number don't open<br />
 v1.3.0 - Support changes to the Trivy output with backward compatibility<br />


### PR DESCRIPTION
Added two new setting values
ServerEnabled and RemoteServerURL. When building the command, we're now checking if the ServerEnabled option is checked and RemoteServerURL, and if it is, inserting --server with the URL provided, into the command.