### PR TITLE
fix: set empty list for results

### DIFF
--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/model/Findings.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/model/Findings.kt
@@ -16,7 +16,7 @@ class Findings {
     var metadata: Metadata? = null
 
     @JsonProperty("Results")
-    var results: List<Result>? = null
+    var results: List<Result>? = emptyList()
 
     fun getBySeverity(severity: Severity?): List<Finding>? {
         return null


### PR DESCRIPTION
If there are no results it will have an empty list rather than causing
an NPE

This is a kotlin version of #14 and Resolves #12
