### PR TITLE
fix: use the correct thread for actions

### DIFF
--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/ClearResultsAction.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/ClearResultsAction.kt
@@ -1,6 +1,7 @@
 package com.aquasecurity.plugins.trivy.actions
 
 import com.aquasecurity.plugins.trivy.ui.TrivyWindow
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
@@ -14,6 +15,10 @@ class ClearResultsAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         super.update(e)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return super.getActionUpdateThread()
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/RunScannerAction.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/RunScannerAction.kt
@@ -1,6 +1,7 @@
 package com.aquasecurity.plugins.trivy.actions
 
 import com.aquasecurity.plugins.trivy.ui.notify.TrivyNotificationGroup
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
@@ -19,6 +20,10 @@ class RunScannerAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         super.update(e)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return super.getActionUpdateThread()
     }
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -43,10 +48,11 @@ class RunScannerAction : AnAction() {
             }
 
             val runner = TrivyBackgroundRunTask(
-                project, resultFile
-            ) { project: Project?, resultFile: File? ->
+                project,
+                resultFile
+            ) { _, _ ->
                 ResultProcessor.updateResults(
-                    project!!, resultFile
+                    project, resultFile
                 )
             }
             if (SwingUtilities.isEventDispatchThread()) {

--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/ShowTrivySettingsAction.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/ShowTrivySettingsAction.kt
@@ -1,5 +1,6 @@
 package com.aquasecurity.plugins.trivy.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.ShowSettingsUtil
@@ -13,5 +14,9 @@ class ShowTrivySettingsAction : AnAction() {
         val project = e.project ?: return
 
         ShowSettingsUtil.getInstance().showSettingsDialog(project, "Trivy: Settings")
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return super.getActionUpdateThread()
     }
 }


### PR DESCRIPTION
The actions should override the getActionUpdateThread() function to
specify where to run

Resolves #17
