### PR TITLE
fix: Handle empty results

### DIFF
--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/ResultProcessor.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/ResultProcessor.kt
@@ -35,6 +35,10 @@ object ResultProcessor {
   }
 
   private fun updatePackageLocations(report: Report) {
+    if (report.results == null) {
+      return
+    }
+
     report.results.forEach { result ->
       result.vulnerabilities?.forEach { vuln ->
         result.packages?.forEach { pkg ->
@@ -56,6 +60,7 @@ object ResultProcessor {
           ObjectMapper(jsonFactory).apply {
             disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
             disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            disable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES)
           }
       findingsMapper.readValue(resultFile, Report::class.java)
     } catch (e: IOException) {

--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/model/oss/Report.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/model/oss/Report.kt
@@ -8,11 +8,17 @@ data class Report(
     @JsonProperty("ArtifactName") val artifactName: String,
     @JsonProperty("ArtifactType") val artifactType: String,
     @JsonProperty("Metadata") val metadata: Metadata,
-    @JsonProperty("Results") val results: List<Result>,
+    @JsonProperty("Results") val results: List<Result>?,
 ) {
 
   fun findMatchingResult(filepath: String, matchId: String): List<Any?> {
+
     var returnResults: List<Any?> = listOf()
+
+      if (results == null) {
+          return returnResults
+      }
+
     val fileResults = results.filter { r -> r.target == filepath }
 
     if (fileResults.isEmpty()) {

--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/ui/TrivyWindow.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/ui/TrivyWindow.kt
@@ -21,20 +21,19 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.ui.JBColor
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPanel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTabbedPane
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.AsyncProcessIcon
+import com.intellij.util.ui.JBEmptyBorder
 import java.awt.BorderLayout
 import java.awt.FlowLayout
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.nio.file.Paths
 import java.util.function.Consumer
-import javax.swing.BorderFactory
-import javax.swing.JComponent
-import javax.swing.JPanel
-import javax.swing.SwingConstants
+import javax.swing.*
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.TreePath
 import com.aquasecurity.plugins.trivy.model.commercial.Result as CommercialResult
@@ -98,7 +97,7 @@ class TrivyWindow(project: Project) : SimpleToolWindowPanel(false, true) {
   }
 
   fun updateFindings(findings: Report?) {
-    if (findings == null) {
+    if (findings == null || findings.results == null) {
       this.findings = null
       return
     }
@@ -263,6 +262,12 @@ class TrivyWindow(project: Project) : SimpleToolWindowPanel(false, true) {
     this.removeAll()
     if (this.findings != null) {
       updateView()
+    } else {
+      val label = JLabel("No results, all looks good!", JLabel.LEFT)
+      label.verticalAlignment = JLabel.TOP
+      label.border = JBEmptyBorder(2)
+
+      this.add(label)
     }
 
     configureToolbar()

--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/ui/treenodes/PolicyTreeNode.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/ui/treenodes/PolicyTreeNode.kt
@@ -23,10 +23,11 @@ class PolicyTreeNode(private val policyTitle: String, result: PolicyResult?) :
       report: Report,
       cr: Result
   ) {
-    // remove the ansi control characters from the title
+
     if (controlResult.type == null) {
       return
     }
+
     val prettyTitle = removeAnsiCodes(controlResult.type)
 
     var existing =
@@ -34,10 +35,6 @@ class PolicyTreeNode(private val policyTitle: String, result: PolicyResult?) :
     if (existing == null) {
       existing = PolicyTreeNode(prettyTitle, result)
       add(existing)
-    }
-
-    if (existing == null) {
-      return
     }
 
     var locationNodes: List<LocationTreeNode> = listOf()


### PR DESCRIPTION
When Trivy runs correctly but has no results, this needs to be handled more gracefully. To fix this, the report now treats Results as nullable

TODO: raised on Windows machine, need to resign commit before merging

Fixes #33 