### PR TITLE
chore: add env var to report the ide type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.10.1]
+- Add Aqua Platform env var to report which type of plugin is sending the results
+
 ## [1.10.0]
 - Add support for custom URLs connecting to Aqua Platform
 - Add support for SAST scan results from Aqua Platform

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 pluginGroup=com.aquasecurity.plugins
 pluginName=Trivy
 pluginRepositoryUrl=https://github.com/aquasecurity/intellij-trivy
-pluginVersion=1.10.0
+pluginVersion=1.10.1
 pluginSinceBuild=241
 platformType=IC
 platformVersion=2024.3.3

--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/TrivyBackgrounRunTask.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/actions/TrivyBackgrounRunTask.kt
@@ -149,6 +149,7 @@ internal class TrivyBackgroundRunTask(
         resultFile.absolutePath.replace(".json", "_assurance.json")
     commandLine.environment["TRIVY_SKIP_REPOSITORY_UPLOAD"] = "true"
     commandLine.environment["TRIVY_SKIP_RESULT_UPLOAD"] = "true"
+    commandLine.environment["TRIVY_IDE_IDENTIFIER"] = "intellij"
 
     if (projectSettings.enableDotNetProject) {
       commandLine.environment["DOTNET_PROJ"] = "1"


### PR DESCRIPTION
Aqua plugin supports an envvar which reports the IDE type that is being
used. This can either be "intellij" or "vscode", although it is
an arbitrary string anyway
