### PR TITLE
feat: add the client to the download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.10.9]
+- Add the client into the download URL when installing Trivy from the plugin settings
+
 ## [1.10.8]
 - Add support for the proxy and CA Certificate
 - Add an output window to see issues with the Trivy execution

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 pluginGroup=com.aquasecurity.plugins
 pluginName=Trivy
 pluginRepositoryUrl=https://github.com/aquasecurity/intellij-trivy
-pluginVersion=1.10.8
+pluginVersion=1.10.9
 pluginSinceBuild=241
 platformType=IC
 platformVersion=2024.3.3

--- a/src/main/kotlin/com/aquasecurity/plugins/trivy/binary/TrivyBinary.kt
+++ b/src/main/kotlin/com/aquasecurity/plugins/trivy/binary/TrivyBinary.kt
@@ -46,7 +46,7 @@ class TrivyBinary {
       }
 
       val tmpFile = kotlin.io.path.createTempFile("trivy-${os}-${arch}", targetSuffix).toFile()
-      downloadFile("${releaseUrl}?os=${os}&arch=${arch}&type=${suffix}", tmpFile)
+      downloadFile("${releaseUrl}?client=jetbrains&os=${os}&arch=${arch}&type=${suffix}", tmpFile)
       val checksums =
         fetchUrl("${checksumUrl}/v${latestTag}/trivy_${latestTag}_checksums.txt")
           .split("\n")


### PR DESCRIPTION
When installing Trivy from the download button in the settings, it goes
through get.trivy.dev - this adds the client arg to the query params to
track the source
